### PR TITLE
ScanAll method at FullPrimaryKey, HashPrimaryKey

### DIFF
--- a/src/query/__test__/full_primary_key_spec.ts
+++ b/src/query/__test__/full_primary_key_spec.ts
@@ -209,6 +209,81 @@ describe("FullPrimaryKey", () => {
       expect(res.records[1].title).to.eq("abc");
     });
   });
+
+  describe("#scanAll", () => {
+    it("should find all items", async () => {
+      await Card.metadata.connection.documentClient.put({
+        TableName: Card.metadata.name,
+        Item: {
+          id: 10,
+          title: "abc",
+        },
+      }).promise();
+      await Card.metadata.connection.documentClient.put({
+        TableName: Card.metadata.name,
+        Item: {
+          id: 10,
+          title: "abd",
+        },
+      }).promise();
+      await Card.metadata.connection.documentClient.put({
+        TableName: Card.metadata.name,
+        Item: {
+          id: 10,
+          title: "aba",
+        },
+      }).promise();
+
+      const res = await primaryKey.scanAll({});
+
+      expect(res.records.length).to.eq(3);
+      // Ordered by range key since it's "scan"
+      expect(res.records[0].title).to.eq("aba");
+      expect(res.records[1].title).to.eq("abc");
+      expect(res.records[2].title).to.eq("abd");
+    });
+
+    it("should find all items with parallelize", async () => {
+      await Card.metadata.connection.documentClient.put({
+        TableName: Card.metadata.name,
+        Item: {
+          id: 10,
+          title: "abc",
+        },
+      }).promise();
+      await Card.metadata.connection.documentClient.put({
+        TableName: Card.metadata.name,
+        Item: {
+          id: 10,
+          title: "abd",
+        },
+      }).promise();
+      await Card.metadata.connection.documentClient.put({
+        TableName: Card.metadata.name,
+        Item: {
+          id: 10,
+          title: "aba",
+        },
+      }).promise();
+      await Card.metadata.connection.documentClient.put({
+        TableName: Card.metadata.name,
+        Item: {
+          id: 10,
+          title: "ccc",
+        },
+      }).promise();
+
+      const res = await primaryKey.scanAll({ parallelize: 3 });
+
+      expect(res.records.length).to.eq(4);
+      // Ordered by range key since it's "scan"
+      expect(res.records[0].title).to.eq("aba");
+      expect(res.records[1].title).to.eq("abc");
+      expect(res.records[2].title).to.eq("abd");
+      expect(res.records[3].title).to.eq("ccc");
+    });
+  });
+
   describe("#update", () => {
     it("should be able to update items", async () => {
       await primaryKey.update(10, "abc", { count: ["ADD", 1] });

--- a/src/query/__test__/full_primary_key_spec.ts
+++ b/src/query/__test__/full_primary_key_spec.ts
@@ -237,10 +237,6 @@ describe("FullPrimaryKey", () => {
       const res = await primaryKey.scanAll({});
 
       expect(res.records.length).to.eq(3);
-      // Ordered by range key since it's "scan"
-      expect(res.records[0].title).to.eq("aba");
-      expect(res.records[1].title).to.eq("abc");
-      expect(res.records[2].title).to.eq("abd");
     });
 
     it("should find all items with parallelize", async () => {

--- a/src/query/__test__/global_secondary_index_spec.ts
+++ b/src/query/__test__/global_secondary_index_spec.ts
@@ -7,6 +7,14 @@ import { Table } from '../../table';
 
 @Decorator.Table({ name: "prod-Card" })
 class Card extends Table {
+  static create(id: number, title: string, count: number) {
+    const record = new this();
+    record.id = id;
+    record.title = title;
+    record.count = count;
+    return record;
+  }
+
   @Decorator.Attribute()
   public id: number;
 
@@ -24,6 +32,9 @@ class Card extends Table {
 
   @Decorator.FullGlobalSecondaryIndex('title', 'id')
   static readonly fullTitleIndex: Query.FullGlobalSecondaryIndex<Card, string, number>;
+
+  @Decorator.Writer()
+  static readonly writer: Query.Writer<Card>;
 }
 
 describe("HashGlobalSecondaryIndex", () => {
@@ -37,33 +48,35 @@ describe("HashGlobalSecondaryIndex", () => {
 
   describe("#query", () => {
     it("should find items", async () => {
-      await Card.metadata.connection.documentClient.put({
-        TableName: Card.metadata.name,
-        Item: {
-          id: 10,
-          title: "abc",
-        },
-      }).promise();
-      await Card.metadata.connection.documentClient.put({
-        TableName: Card.metadata.name,
-        Item: {
-          id: 11,
-          title: "abd",
-        },
-      }).promise();
-      await Card.metadata.connection.documentClient.put({
-        TableName: Card.metadata.name,
-        Item: {
-          id: 12,
-          title: "abd",
-        },
-      }).promise();
-
+      await Card.writer.batchPut([
+        Card.create(10, "abc", 1),
+        Card.create(11, "abd", 1),
+        Card.create(12, "abd", 1),
+      ]);
 
       const res = await Card.hashTitleIndex.query("abd");
       expect(res.records.length).to.eq(2);
       expect(res.records[0].id).to.eq(12);
       expect(res.records[1].id).to.eq(11);
+    });
+  });
+
+  describe("#scanAll", () => {
+    it("should find all items", async () => {
+      await Card.writer.batchPut([
+        Card.create(10, "abc", 1),
+        Card.create(11, "abd", 1),
+        Card.create(12, "abd", 1),
+        Card.create(13, "abd", 1),
+        Card.create(14, "abe", 1),
+        Card.create(15, "abe", 1),
+      ]);
+      const res = await Card.hashTitleIndex.scanAll({
+        scanBatchSize: 1,
+        parallelize: 3,
+      });
+
+      expect(res.records.length).to.eq(6);
     });
   });
 });
@@ -79,36 +92,12 @@ describe("FullGlobalSecondaryIndex", () => {
 
   describe("#query", () => {
     it("should find items", async () => {
-      await Card.metadata.connection.documentClient.put({
-        TableName: Card.metadata.name,
-        Item: {
-          id: 10,
-          title: "abc",
-        },
-      }).promise();
-      await Card.metadata.connection.documentClient.put({
-        TableName: Card.metadata.name,
-        Item: {
-          id: 11,
-          title: "abd",
-        },
-      }).promise();
-      await Card.metadata.connection.documentClient.put({
-        TableName: Card.metadata.name,
-        Item: {
-          id: 12,
-          title: "abd",
-        },
-      }).promise();
-      await Card.metadata.connection.documentClient.put({
-        TableName: Card.metadata.name,
-        Item: {
-          id: 13,
-          title: "abd",
-        },
-      }).promise();
-
-
+      await Card.writer.batchPut([
+        Card.create(10, "abc", 1),
+        Card.create(11, "abd", 1),
+        Card.create(12, "abd", 1),
+        Card.create(13, "abd", 1),
+      ]);
       const res = await Card.fullTitleIndex.query({
         hash: "abd",
         range: [">=", 12],
@@ -118,6 +107,24 @@ describe("FullGlobalSecondaryIndex", () => {
 
       expect(res.records[0].id).to.eq(13);
       expect(res.records[1].id).to.eq(12);
+    });
+  });
+
+  describe("#scanAll", () => {
+    it("should find all items", async () => {
+      await Card.writer.batchPut([
+        Card.create(10, "abc", 1),
+        Card.create(11, "abd", 1),
+        Card.create(12, "abd", 1),
+        Card.create(13, "abd", 1),
+        Card.create(14, "abe", 1),
+        Card.create(15, "abe", 1),
+      ]);
+      const res = await Card.fullTitleIndex.scanAll({
+        scanBatchSize: 1,
+        parallelize: 3,
+      });
+      expect(res.records.length).to.eq(6);
     });
   });
 });

--- a/src/query/__test__/hash_primary_key_spec.ts
+++ b/src/query/__test__/hash_primary_key_spec.ts
@@ -105,9 +105,16 @@ describe("HashPrimaryKey", () => {
         await createCard(),
         await createCard(),
         await createCard(),
+        await createCard(),
+        await createCard(),
+        await createCard(),
+        await createCard(),
+        await createCard(),
+        await createCard(),
+        await createCard(),
       ];
 
-      const res = await primaryKey.scanAll({});
+      const res = await primaryKey.scanAll({ scanBatchSize: 1 });
 
       const ids = _.sortBy(
         res.records,

--- a/src/query/__test__/hash_primary_key_spec.ts
+++ b/src/query/__test__/hash_primary_key_spec.ts
@@ -91,6 +91,57 @@ describe("HashPrimaryKey", () => {
     });
   });
 
+  describe("#scanAll", () => {
+    it("should find all items", async () => {
+      async function createCard() {
+        const card = new Card();
+        card.id = faker.random.number();
+        await card.save();
+        return card;
+      }
+
+      const cards = [
+        await createCard(),
+        await createCard(),
+        await createCard(),
+        await createCard(),
+      ];
+
+      const res = await primaryKey.scanAll({});
+
+      const ids = _.sortBy(
+        res.records,
+        (item) => item.id,
+      ).map((c) => c.id);
+
+      expect(ids).to.deep.eq( _.sortBy(cards.map((c) => c.id), (i) => i) );
+    });
+
+    it("should find all items with parallelize", async () => {
+      async function createCard() {
+        const card = new Card();
+        card.id = faker.random.number();
+        await card.save();
+        return card;
+      }
+
+      const cards = [
+        await createCard(),
+        await createCard(),
+        await createCard(),
+        await createCard(),
+      ];
+
+      const res = await primaryKey.scanAll({ parallelize: 3 });
+
+      const ids = _.sortBy(
+        res.records,
+        (item) => item.id,
+      ).map((c) => c.id);
+
+      expect(ids).to.deep.eq( _.sortBy(cards.map((c) => c.id), (i) => i) );
+    });
+  });
 
   describe("#batchGet", async () => {
     it ("should return results in order", async () => {

--- a/src/query/__test__/local_secondary_index_spec.ts
+++ b/src/query/__test__/local_secondary_index_spec.ts
@@ -64,4 +64,23 @@ describe("LocalSecondaryIndex", () => {
       expect(res.records[1].count).to.eq(3);
     });
   });
+
+  describe("#scanAll", () => {
+    it("should find all items", async () => {
+      await Card.writer.batchPut([
+        Card.create(10, "abc", 1),
+        Card.create(11, "abd", 2),
+        Card.create(12, "abd", 3),
+        Card.create(13, "abd", 4),
+        Card.create(14, "abe", 5),
+        Card.create(15, "abe", 6),
+      ]);
+      const res = await Card.countIndex.scanAll({
+        scanBatchSize: 1,
+        parallelize: 3,
+      });
+
+      expect(res.records.length).to.eq(6);
+    });
+  });
 });

--- a/src/query/full_primary_key.ts
+++ b/src/query/full_primary_key.ts
@@ -191,10 +191,6 @@ export class FullPrimaryKey<T extends Table, HashKeyType, RangeKeyType> {
     parallelize?: number;
     scanBatchSize?: number;
   }) {
-    if (options.parallelize && options.parallelize < 1) {
-      throw new Error("Parallelize value at scanAll always positive number");
-    }
-
     const res = await scanAll(
       this.tableClass.metadata.connection.documentClient,
       this.tableClass.metadata.name,

--- a/src/query/global_secondary_index.ts
+++ b/src/query/global_secondary_index.ts
@@ -74,10 +74,6 @@ export class FullGlobalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType
     parallelize?: number;
     scanBatchSize?: number;
   }) {
-    if (options.parallelize && options.parallelize < 1) {
-      throw new Error("Parallelize value at scanAll always positive number");
-    }
-
     const res = await scanAll(
       this.tableClass.metadata.connection.documentClient,
       this.tableClass.metadata.name,

--- a/src/query/global_secondary_index.ts
+++ b/src/query/global_secondary_index.ts
@@ -7,6 +7,8 @@ import * as Codec from '../codec';
 import * as Metadata from '../metadata';
 import * as Query from './query';
 
+import { scanAll } from './scan_all';
+
 const HASH_KEY_REF = "#hk";
 const HASH_VALUE_REF = ":hkv";
 
@@ -67,6 +69,26 @@ export class FullGlobalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType
       consumedCapacity: result.ConsumedCapacity,
     };
   }
+
+  async scanAll(options: {
+    parallelize?: number;
+    scanBatchSize?: number;
+  }) {
+    if (options.parallelize && options.parallelize < 1) {
+      throw new Error("Parallelize value at scanAll always positive number");
+    }
+
+    const res = await scanAll(
+      this.tableClass.metadata.connection.documentClient,
+      this.tableClass.metadata.name,
+      options,
+    );
+
+    return {
+      records: res.map((item) => Codec.deserialize(this.tableClass, item)),
+      count: res.length,
+    };
+  }
 }
 
 export class HashGlobalSecondaryIndex<T extends Table, HashKeyType> {
@@ -101,6 +123,26 @@ export class HashGlobalSecondaryIndex<T extends Table, HashKeyType> {
       scannedCount: result.ScannedCount,
       lastEvaluatedKey: result.LastEvaluatedKey,
       consumedCapacity: result.ConsumedCapacity,
+    };
+  }
+
+  async scanAll(options: {
+    parallelize?: number;
+    scanBatchSize?: number;
+  }) {
+    if (options.parallelize && options.parallelize < 1) {
+      throw new Error("Parallelize value at scanAll always positive number");
+    }
+
+    const res = await scanAll(
+      this.tableClass.metadata.connection.documentClient,
+      this.tableClass.metadata.name,
+      options,
+    );
+
+    return {
+      records: res.map((item) => Codec.deserialize(this.tableClass, item)),
+      count: res.length,
     };
   }
 }

--- a/src/query/hash_primary_key.ts
+++ b/src/query/hash_primary_key.ts
@@ -7,6 +7,7 @@ import { ITable, Table } from '../table';
 
 import { batchGetFull, batchGetTrim } from "./batch_get";
 import { batchWrite } from "./batch_write";
+import { scanAll } from './scan_all';
 
 export class HashPrimaryKey<T extends Table, HashKeyType> {
   constructor(
@@ -69,43 +70,21 @@ export class HashPrimaryKey<T extends Table, HashKeyType> {
 
   async scanAll(options: {
     parallelize?: number;
-    limit?: number;
+    scanBatchSize?: number;
   }) {
     if (options.parallelize && options.parallelize < 1) {
       throw new Error("Parallelize value at scanAll always positive number");
     }
-    const buffer: T[] = [];
-    const totalSegments = options.parallelize || 1;
-    const scanners = _.times(totalSegments)
-      .map((i) => (async (exclusiveStartKey?: DynamoDB.DocumentClient.Key) =>
-        await this.scan({
-          limit: options.limit,
-          totalSegments,
-          segment: i,
-          exclusiveStartKey,
-        })),
-      );
-    let lastEvaluatedKeys = new Array<DynamoDB.DocumentClient.Key | undefined>(totalSegments);
-    _.fill(lastEvaluatedKeys, undefined);
 
-    do {
-      const results = await Promise.all(
-        _.times(totalSegments)
-          .map((i) => scanners[i](lastEvaluatedKeys[i])),
-      );
-
-      buffer.push(
-        ..._.chain(results)
-          .map(({ records }) => records)
-          .flatten()
-          .value(),
-      );
-      lastEvaluatedKeys = results.map(({ lastEvaluatedKey }) => lastEvaluatedKey);
-    } while(_.compact(lastEvaluatedKeys).length);
+    const res = await scanAll(
+      this.tableClass.metadata.connection.documentClient,
+      this.tableClass.metadata.name,
+      options,
+    );
 
     return {
-      records: buffer,
-      count: buffer.length,
+      records: res.map((item) => Codec.deserialize(this.tableClass, item)),
+      count: res.length,
     };
   }
 

--- a/src/query/hash_primary_key.ts
+++ b/src/query/hash_primary_key.ts
@@ -72,10 +72,6 @@ export class HashPrimaryKey<T extends Table, HashKeyType> {
     parallelize?: number;
     scanBatchSize?: number;
   }) {
-    if (options.parallelize && options.parallelize < 1) {
-      throw new Error("Parallelize value at scanAll always positive number");
-    }
-
     const res = await scanAll(
       this.tableClass.metadata.connection.documentClient,
       this.tableClass.metadata.name,

--- a/src/query/hash_primary_key.ts
+++ b/src/query/hash_primary_key.ts
@@ -1,4 +1,5 @@
 import { DynamoDB } from 'aws-sdk';
+import * as _ from 'lodash';
 
 import * as Codec from '../codec';
 import * as Metadata from '../metadata';
@@ -63,6 +64,48 @@ export class HashPrimaryKey<T extends Table, HashKeyType> {
       scannedCount: result.ScannedCount,
       lastEvaluatedKey: result.LastEvaluatedKey,
       consumedCapacity: result.ConsumedCapacity,
+    };
+  }
+
+  async scanAll(options: {
+    parallelize?: number;
+    limit?: number;
+  }) {
+    if (options.parallelize && options.parallelize < 1) {
+      throw new Error("Parallelize value at scanAll always positive number");
+    }
+    const buffer: T[] = [];
+    const totalSegments = options.parallelize || 1;
+    const scanners = _.times(totalSegments)
+      .map((i) => (async (exclusiveStartKey?: DynamoDB.DocumentClient.Key) =>
+        await this.scan({
+          limit: options.limit,
+          totalSegments,
+          segment: i,
+          exclusiveStartKey,
+        })),
+      );
+    let lastEvaluatedKeys = new Array<DynamoDB.DocumentClient.Key | undefined>(totalSegments);
+    _.fill(lastEvaluatedKeys, undefined);
+
+    do {
+      const results = await Promise.all(
+        _.times(totalSegments)
+          .map((i) => scanners[i](lastEvaluatedKeys[i])),
+      );
+
+      buffer.push(
+        ..._.chain(results)
+          .map(({ records }) => records)
+          .flatten()
+          .value(),
+      );
+      lastEvaluatedKeys = results.map(({ lastEvaluatedKey }) => lastEvaluatedKey);
+    } while(_.compact(lastEvaluatedKeys).length);
+
+    return {
+      records: buffer,
+      count: buffer.length,
     };
   }
 

--- a/src/query/local_secondary_index.ts
+++ b/src/query/local_secondary_index.ts
@@ -7,6 +7,8 @@ import * as Codec from '../codec';
 import * as Metadata from '../metadata';
 import * as Query from './query';
 
+import { scanAll } from './scan_all';
+
 const HASH_KEY_REF = "#hk";
 const HASH_VALUE_REF = ":hkv";
 
@@ -65,6 +67,26 @@ export class LocalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType> {
       scannedCount: result.ScannedCount,
       lastEvaluatedKey: result.LastEvaluatedKey,
       consumedCapacity: result.ConsumedCapacity,
+    };
+  }
+
+  async scanAll(options: {
+    parallelize?: number;
+    scanBatchSize?: number;
+  }) {
+    if (options.parallelize && options.parallelize < 1) {
+      throw new Error("Parallelize value at scanAll always positive number");
+    }
+
+    const res = await scanAll(
+      this.tableClass.metadata.connection.documentClient,
+      this.tableClass.metadata.name,
+      options,
+    );
+
+    return {
+      records: res.map((item) => Codec.deserialize(this.tableClass, item)),
+      count: res.length,
     };
   }
 }

--- a/src/query/local_secondary_index.ts
+++ b/src/query/local_secondary_index.ts
@@ -74,10 +74,6 @@ export class LocalSecondaryIndex<T extends Table, HashKeyType, RangeKeyType> {
     parallelize?: number;
     scanBatchSize?: number;
   }) {
-    if (options.parallelize && options.parallelize < 1) {
-      throw new Error("Parallelize value at scanAll always positive number");
-    }
-
     const res = await scanAll(
       this.tableClass.metadata.connection.documentClient,
       this.tableClass.metadata.name,

--- a/src/query/scan_all.ts
+++ b/src/query/scan_all.ts
@@ -1,0 +1,47 @@
+import { DynamoDB } from "aws-sdk";
+import * as _ from "lodash";
+
+export async function scanAll(
+  documentClient: DynamoDB.DocumentClient,
+  tableName: string,
+  options: {
+    parallelize?: number;
+    scanBatchSize?: number;
+  },
+) {
+  if (options.parallelize && options.parallelize < 1) {
+    throw new Error("Parallelize value at scanAll always positive number");
+  }
+  const buffer: DynamoDB.AttributeMap[] = [];
+  const totalSegments = options.parallelize || 1;
+  const scanners = _.times(totalSegments)
+    .map((i) => (async (exclusiveStartKey?: DynamoDB.DocumentClient.Key) =>
+      await documentClient.scan({
+        TableName: tableName,
+        Limit: options.scanBatchSize,
+        ExclusiveStartKey: exclusiveStartKey,
+        ReturnConsumedCapacity: "TOTAL",
+        TotalSegments: totalSegments,
+        Segment: i,
+      }).promise()),
+    );
+  let lastEvaluatedKeys = new Array<DynamoDB.DocumentClient.Key | undefined>(totalSegments);
+  _.fill(lastEvaluatedKeys, undefined);
+
+  do {
+    const results = await Promise.all(
+      _.times(totalSegments)
+        .map((i) => scanners[i](lastEvaluatedKeys[i])),
+    );
+
+    buffer.push(
+      ..._.chain(results)
+        .map(({ Items }) => (Items || []))
+        .flatten()
+        .value(),
+    );
+    lastEvaluatedKeys = results.map(({ LastEvaluatedKey }) => LastEvaluatedKey);
+  } while(_.compact(lastEvaluatedKeys).length);
+
+  return buffer;
+}


### PR DESCRIPTION
## BACKEND-STORY_ID One-sentence summary of changes

#### Is it a breaking change?: NO

### Why did you make these changes?

When scan all records, for iteration, code is so dirty.
So, i think scanAll support at ORM layer.

### What's changed in these changes?

I added `scanAll` method to `FullPrimaryKey` class.
I added `scanAll` method to `HashPrimaryKey` class.

### What do you especially want to get reviewed?

Is parameter 'limit' of scanAll method needed?.

### Is there any other comments that every teammate should know?

nope.


### Submission Type

* [ ] Bugfix
* [x] New Feature
* [ ] Refactor

### All Submissions

* [x] Have you added an explanation of what your changes?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you checked potential side effects that could make bad impacts to other services?


### New Features

* [x] Have you configured CI/CD properly?
* [x] Have you configured optimal memory size and timeouts of Lambda Function?
* [ ] Have you grant required permissions (e.g. IAM Policy, VPC Security Group)?
* [ ] Have you made required resources (e.g. DynamoDB Table, RDS Cluster)?
* [ ] Does it requires native addons dependency?
